### PR TITLE
add pacer based on wall clock instead of relative differences in duration

### DIFF
--- a/etc/dummyweb.go
+++ b/etc/dummyweb.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"time"
 )
@@ -10,6 +12,7 @@ var count int
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	count++
+	time.Sleep(time.Duration(rand.Intn(250)) * time.Millisecond)
 	w.Write([]byte("hi\n"))
 }
 
@@ -17,7 +20,7 @@ func main() {
 	// Crude RPS reporting
 	go func() {
 		for {
-			println(count)
+			fmt.Printf("rps: %d\n", count)
 			count = 0
 			time.Sleep(time.Second)
 		}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func main() {
 	silent := flag.Bool("silent", false, "Suppress output")
 	dryRun := flag.Bool("dry-run", false, "Consume input but do not send HTTP requests to targets")
 	timeout := flag.Int("timeout", 10, "HTTP client timeout in seconds")
+	connections := flag.Int("connections", 10000, "Max open idle connections per target host")
+	maxConnections := flag.Int("max-connections", 0, "Max connections per target host (default unlimited)")
 	strict := flag.Bool("strict", false, "Panic on bad input")
 	memprofile := flag.String("memprofile", "", "Write memory profile to `file` before exit")
 	cpuprofile := flag.String("cpuprofile", "", "Write cpu profile to `file` before exit")
@@ -58,7 +60,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	exitCode = ripley.Replay(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers)
+	exitCode = ripley.Replay(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers, *connections, *maxConnections)
 
 	if *memprofile != "" {
 		f, err := os.Create(*memprofile)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	strict := flag.Bool("strict", false, "Panic on bad input")
 	memprofile := flag.String("memprofile", "", "Write memory profile to `file` before exit")
 	cpuprofile := flag.String("cpuprofile", "", "Write cpu profile to `file` before exit")
-	numWorkers := flag.Int("workers", 1000, "Number of client workers to use")
+	numWorkers := flag.Int("workers", runtime.NumCPU()*2, "Number of client workers to use")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,32 @@ func main() {
 	memprofile := flag.String("memprofile", "", "Write memory profile to `file` before exit")
 	cpuprofile := flag.String("cpuprofile", "", "Write cpu profile to `file` before exit")
 	numWorkers := flag.Int("workers", runtime.NumCPU()*2, "Number of client workers to use")
+	printStatsInterval := flag.Duration("print-stats", 0, `Statistics report interval, e.g., "1m"
+
+Each report line are printed to stderr with the following fields in logfmt format:
+
+  report_time
+    The calculated wall time for when this line should be printed in RFC3339 format.
+
+  skew_seconds
+    Difference between "report_time" and current time in seconds. When the absolute
+    value of this is higher than about 100ms, it shows that ripley cannot generate
+    enough load. Consider increasing workers, max connections, and/or CPU and IO requests.
+
+  last_request_time
+    Original request time of the last request in RFC3339 format.
+
+  rate
+    Current rate of playback as specified in "pace" flag.
+
+  expected_rps
+    Expected requests per seconds since that last report. This will differ from the
+    actual requests per seconds if the system is unable to drive that many requests.
+    If that is the case, consider increasing workers, max connections, and/or
+    CPU and IO requests.
+
+When 0 (default) or negative, reporting is switched off.
+  `)
 
 	flag.Parse()
 
@@ -60,7 +86,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	exitCode = ripley.Replay(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers, *connections, *maxConnections)
+	exitCode = ripley.Replay(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers, *connections, *maxConnections, *printStatsInterval)
 
 	if *memprofile != "" {
 		f, err := os.Create(*memprofile)

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	numWorkers := flag.Int("workers", runtime.NumCPU()*2, "Number of client workers to use")
 	printStatsInterval := flag.Duration("print-stats", 0, `Statistics report interval, e.g., "1m"
 
-Each report line are printed to stderr with the following fields in logfmt format:
+Each report line is printed to stderr with the following fields in logfmt format:
 
   report_time
     The calculated wall time for when this line should be printed in RFC3339 format.
@@ -60,8 +60,8 @@ Each report line are printed to stderr with the following fields in logfmt forma
     Current rate of playback as specified in "pace" flag.
 
   expected_rps
-    Expected requests per seconds since that last report. This will differ from the
-    actual requests per seconds if the system is unable to drive that many requests.
+    Expected requests per second since the last report. This will differ from the
+    actual requests per second if the system is unable to drive that many requests.
     If that is the case, consider increasing workers, max connections, and/or
     CPU and IO requests.
 

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -39,7 +39,7 @@ func startClientWorkers(numWorkers int, requests <-chan *request, results chan<-
 		},
 	}
 
-	for i := 0; i <= numWorkers; i++ {
+	for i := 0; i < numWorkers; i++ {
 		go doHttpRequest(client, requests, results, dryRun)
 	}
 }

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -31,11 +31,15 @@ type Result struct {
 	ErrorMsg   string        `json:"error"`
 }
 
-func startClientWorkers(numWorkers int, requests <-chan *request, results chan<- *Result, dryRun bool, timeout int) {
+func startClientWorkers(numWorkers int, requests <-chan *request, results chan<- *Result, dryRun bool, timeout, connections, maxConnections int) {
 	client := &http.Client{
 		Timeout: time.Duration(timeout) * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: connections,
+			MaxConnsPerHost:     maxConnections,
 		},
 	}
 

--- a/pkg/pace.go
+++ b/pkg/pace.go
@@ -26,10 +26,10 @@ import (
 
 type pacer struct {
 	phases                []*phase
-	lastRequestTime       time.Time
-	lastRequestWallTime   time.Time
-	phaseStartWallTime    time.Time
+	lastRequestTime       time.Time // last request that we already replayed in "log time"
+	lastRequestWallTime   time.Time // last request that we already replayed in "wall time"
 	phaseStartRequestTime time.Time
+	phaseStartWallTime    time.Time
 	done                  bool
 }
 
@@ -84,7 +84,7 @@ func (p *pacer) waitDuration(t time.Time) time.Duration {
 
 	duration := expectedWallTime.Sub(now)
 	p.lastRequestTime = t
-	p.lastRequestWallTime = now
+	p.lastRequestWallTime = expectedWallTime
 	return duration
 }
 

--- a/pkg/pace_test.go
+++ b/pkg/pace_test.go
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package ripley
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -83,15 +84,15 @@ func TestWaitDuration(t *testing.T) {
 	now := time.Now()
 	duration := pacer.waitDuration(now)
 
-	if duration != 0 {
-		t.Errorf("duration = %v; want 0", duration)
+	if duration > 0 {
+		t.Errorf("duration = %v; want 0 or negative", duration)
 	}
 
 	now = now.Add(2 * time.Second)
 	duration = pacer.waitDuration(now)
 	expected := 2 * time.Second
 
-	if duration != expected {
+	if !equalsWithinThreshold(duration, expected, 10*time.Microsecond) {
 		t.Errorf("duration = %v; want %v", duration, expected)
 	}
 }
@@ -106,15 +107,15 @@ func TestWaitDuration10X(t *testing.T) {
 	now := time.Now()
 	duration := pacer.waitDuration(now)
 
-	if duration != 0 {
-		t.Errorf("duration = %v; want 0", duration)
+	if duration > 0 {
+		t.Errorf("duration = %v; want 0 or negative", duration)
 	}
 
 	now = now.Add(1 * time.Second)
 	duration = pacer.waitDuration(now)
 	expected := time.Second / 10
 
-	if duration != expected {
+	if !equalsWithinThreshold(duration, expected, 10*time.Microsecond) {
 		t.Errorf("duration = %v; want %v", duration, expected)
 	}
 }
@@ -135,4 +136,8 @@ func TestPacerDoneOnLastPhaseElapsed(t *testing.T) {
 	if !pacer.done {
 		t.Errorf("pacer.done = %v; want true", pacer.done)
 	}
+}
+
+func equalsWithinThreshold(d1, d2, threshold time.Duration) bool {
+	return math.Abs(float64(d1-d2)) <= float64(threshold)
 }

--- a/pkg/replay.go
+++ b/pkg/replay.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers int) int {
+func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers, connections, maxConnections int) int {
 	// Default exit code
 	var exitCode int = 0
 	// Ensures we have handled all HTTP request results before exiting
@@ -52,7 +52,7 @@ func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, num
 	scanner := bufio.NewScanner(bufio.NewReaderSize(os.Stdin, 32*1024*1024))
 
 	// Start HTTP client goroutine pool
-	startClientWorkers(numWorkers, requests, results, dryRun, timeout)
+	startClientWorkers(numWorkers, requests, results, dryRun, timeout, connections, maxConnections)
 	pacer.start()
 
 	// Goroutine to handle the  HTTP client result

--- a/pkg/replay.go
+++ b/pkg/replay.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers, connections, maxConnections int) int {
+func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers, connections, maxConnections int, printStatsInterval time.Duration) int {
 	// Default exit code
 	var exitCode int = 0
 	// Ensures we have handled all HTTP request results before exiting
@@ -43,6 +43,7 @@ func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, num
 
 	// The pacer controls the rate of replay
 	pacer, err := newPacer(phasesStr)
+	pacer.ReportInterval = printStatsInterval
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The reason for the change is that errors in pacing add up if we pace relative to
the previous request, but do not add up if we always do our calculations relative
to the start of the phase.

Like measuring 1 meter by measuing 2 millimeters on top of each other 500 times
will not be as accurate as measuring the 1 meter in one go.

The source of errors is simply execution time.
