### PR TITLE
Fixing GoReleaser

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -30,6 +30,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_GORELEASER }}


### PR DESCRIPTION
`--rm-dist` was deprecated in favour of `--clean`
[docs](https://goreleaser.com/deprecations/#-rm-dist)

[Failed GoReleaser run](https://github.com/loveholidays/ripley/actions/runs/10117374294/job/27982198236)