### PR TITLE
fix go version: 1.22 -> 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/loveholidays/ripley
 
-go 1.22
+go 1.22.0


### PR DESCRIPTION
I was having trouble running it locally:

![Screenshot 2024-12-12 at 16 16 43](https://github.com/user-attachments/assets/ed51acee-6aaa-4d9b-8423-a21f794db2ca)

Until I changed the go version to be `1.22.0`


