### PR TITLE
Fix panic on malformed -pace input

### DIFF
--- a/pkg/pace.go
+++ b/pkg/pace.go
@@ -152,19 +152,26 @@ func (p *pacer) reportStats(now, expectedWallTime time.Time) {
 func parsePhases(phasesStr string) ([]*phase, error) {
 	var phases []*phase
 
-	for _, durationAtRate := range strings.Split(phasesStr, " ") {
+	for _, durationAtRate := range strings.Fields(phasesStr) {
 		tokens := strings.Split(durationAtRate, "@")
+
+		if len(tokens) != 2 {
+			return nil, fmt.Errorf("invalid phase %q: expected [duration]@[rate], e.g. 10s@1.5", durationAtRate)
+		}
 
 		duration, err := time.ParseDuration(tokens[0])
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid duration in phase %q: %w", durationAtRate, err)
 		}
 
 		rate, err := strconv.ParseFloat(tokens[1], 64)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid rate in phase %q: %w", durationAtRate, err)
+		}
+		if rate <= 0 || duration <= 0 {
+			return nil, fmt.Errorf("invalid phase %q: rate and duration must be positive", durationAtRate)
 		}
 
 		phases = append(phases, &phase{duration, rate})

--- a/pkg/pace_test.go
+++ b/pkg/pace_test.go
@@ -141,3 +141,15 @@ func TestPacerDoneOnLastPhaseElapsed(t *testing.T) {
 func equalsWithinThreshold(d1, d2, threshold time.Duration) bool {
 	return math.Abs(float64(d1-d2)) <= float64(threshold)
 }
+
+func TestParsePhasesErrors(t *testing.T) {
+	for _, input := range []string{
+		"10s", "10s@", "@5", "bad", "10s@0", "10s@-1", "10s@abc",
+	} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := parsePhases(input); err == nil {
+				t.Errorf("parsePhases(%q) = nil; want error", input)
+			}
+		})
+	}
+}

--- a/pkg/replay.go
+++ b/pkg/replay.go
@@ -51,11 +51,11 @@ func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, num
 
 	// The pacer controls the rate of replay
 	pacer, err := newPacer(phasesStr)
-	pacer.ReportInterval = printStatsInterval
-
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, "ripley: invalid -pace value:", err)
+		return 1
 	}
+	pacer.ReportInterval = printStatsInterval
 
 	// Read Request JSONL input from STDIN
 	scanner := bufio.NewScanner(bufio.NewReaderSize(os.Stdin, 32*1024*1024))


### PR DESCRIPTION
## Summary

A malformed `-pace` value crashed ripley with a raw Go stack trace
instead of a usable error message. 

Three distinct defects, all triggered before any HTTP is sent:

1. **Index panic** — a phase missing `@` (e.g. `10s`) indexed `tokens[1]`
   out of range inside `parsePhases`.
2. **Nil-pointer panic** — an invalid duration (e.g. `bad`) returned
   `(nil, err)` from `newPacer`, but `Replay` dereferenced the nil pacer
   before checking the error.
3. **Silent misbehaviour** — a zero/negative rate (e.g. `10s@0`) passed
   parsing and caused a divide-by-zero in `waitDuration`, disabling
   pacing without any warning.

## Before

```bash
ripley -pace "10s" < /dev/null
panic: runtime error: index out of range 1 with length 1
    .../pkg/pace.go:164 ...
```

```bash
ripley -pace "bad" < /dev/null
panic: runtime error: invalid memory address or nil pointer dereference
signal SIGSEGV: segmentation violation ...
    .../pkg/replay.go:54 ...
```

## After
```bash
ripley -pace "10s" < /dev/null
ripley: invalid -pace value: invalid phase "10s": expected [duration]@[rate], e.g. 10s@1.5
```
```bash
$ ripley -pace "10s@0" < /dev/null
ripley: invalid -pace value: invalid phase "10s@0": rate and duration must be positive
```

Valid pace strings are unaffected.

## Changes

- `pkg/pace.go` — `parsePhases` now validates token count, `duration > 0`
  and `rate > 0`, returning wrapped errors. Switched to `strings.Fields`
  so extra/trailing whitespace no longer produces empty tokens.
- `pkg/replay.go` — check the `newPacer` error before using the pacer;
  print to stderr and return a non-zero exit code. Removed the now-dead
  `panic` block.
- `pkg/pace_test.go` — table-driven tests for the malformed inputs above.