### PR TITLE
feat: add Ripley job observability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,15 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
 permissions:
   id-token: write
   contents: write
+
 jobs:
   test:
     name: Test
@@ -14,13 +17,16 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -30,33 +36,56 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
+
       - name: Download dependencies
         run: go mod download
+
       - name: Verify dependencies
         run: go mod verify
+
       - name: Run tests
         run: go test -v -race ./...
+
       - name: Test linkerdxripley tool
         run: |
           cd tools/linkerdxripley
           go test -v -race ./...
+
   build:
     name: Binaries Build
     runs-on: ubuntu-latest
     needs: test
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Authenticate
-        uses: loveholidays/github-actions/.github/actions/auth-cicd@v1
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+        with:
+          token_format: access_token
+          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
+          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
+
+      - name: Login to GCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
+
       - name: docker registry configure europe-docker.pkg.dev for gcloud
         run: gcloud auth configure-docker europe-docker.pkg.dev
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
+
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -66,16 +95,20 @@ jobs:
           key: ${{ runner.os }}-go-1.23.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-1.23.x-
+
       - name: Build main binary
         run: go build -v -o ripley main.go
+
       - name: Build linkerdxripley tool
         run: |
           cd tools/linkerdxripley
           go build -v -o linkerdxripley main.go
+
       - name: Test binaries work
         run: |
           ./ripley --help
           ./tools/linkerdxripley/linkerdxripley --help
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -83,39 +116,62 @@ jobs:
           path: |
             ripley
             tools/linkerdxripley/linkerdxripley
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=5m
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
     needs: [test, build]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Authenticate
-        uses: loveholidays/github-actions/.github/actions/auth-cicd@v1
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+        with:
+          token_format: access_token
+          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
+          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
+
+      - name: Login to GCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: binaries
           path: .
+
       - name: Make binaries executable
         run: chmod +x ripley tools/linkerdxripley/linkerdxripley
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
@@ -128,6 +184,7 @@ jobs:
             eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Test Docker image
         run: |
           docker run --rm eu.gcr.io/loveholidays-ci-cd/ripley:latest --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,6 +185,7 @@ jobs:
 
   docker-hub:
     name: Docker Push Docker Hub
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [test, build, docker]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,6 @@ jobs:
 
   docker-gcr:
     name: Docker Push GCR
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [test, build, docker]
 
@@ -185,7 +184,6 @@ jobs:
 
   docker-hub:
     name: Docker Push Docker Hub
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [test, build, docker]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,3 +214,65 @@ jobs:
             loveholidays/ripley:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release-tag:
+    name: Create release tag
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: [test, lint, build, docker, docker-gcr, docker-hub]
+    concurrency:
+      group: ripley-release-tag-main
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TOKEN_GORELEASER }}
+
+      - name: Calculate release version
+        id: version
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force
+
+          existing_tag="$(git tag --points-at "$GITHUB_SHA" --list 'v[0-9]*' | sort -V | tail -n 1)"
+          if [[ -n "$existing_tag" ]]; then
+            echo "tag=$existing_tag" >> "$GITHUB_OUTPUT"
+            echo "create_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          current_tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+          if [[ ! "$current_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Expected a semantic version tag, found: ${current_tag:-none}" >&2
+            exit 1
+          fi
+
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
+          if [[ "$COMMIT_MESSAGE" == *"#major"* ]]; then
+            major=$((major + 1))
+            minor=0
+          else
+            minor=$((minor + 1))
+          fi
+
+          echo "tag=v${major}.${minor}.0" >> "$GITHUB_OUTPUT"
+          echo "create_tag=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push release tag
+        if: ${{ steps.version.outputs.create_tag == 'true' }}
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,32 +124,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        if: ${{ github.event_name == 'push' }}
-        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-        with:
-          token_format: access_token
-          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
-          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
-
-      - name: Login to GCR
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: eu.gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries
-          path: .
-
-      - name: Make binaries executable
-        run: chmod +x ripley tools/linkerdxripley/linkerdxripley
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -158,15 +132,85 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name == 'push' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          platforms: ${{ github.event_name == 'push' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          load: true
+          platforms: linux/amd64
+          tags: ripley:ci-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test Docker image
+        run: |
+          docker run --rm ripley:ci-${{ github.sha }} --help
+
+  docker-gcr:
+    name: Docker Push GCR
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    needs: [test, build, docker]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+        with:
+          token_format: access_token
+          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
+          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
+
+      - name: Login to GCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push GCR image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             eu.gcr.io/loveholidays-ci-cd/ripley:latest
             eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Test Docker image
-        run: |
-          docker run --rm eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }} --help
+  docker-hub:
+    name: Docker Push Docker Hub
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    needs: [test, build, docker]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker Hub image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            loveholidays/ripley:latest
+            loveholidays/ripley:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,27 +60,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-        with:
-          token_format: access_token
-          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
-          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
-
-      - name: Login to GCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: eu.gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v2"
-
-      - name: docker registry configure europe-docker.pkg.dev for gcloud
-        run: gcloud auth configure-docker europe-docker.pkg.dev
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -147,6 +126,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
+        if: ${{ github.event_name == 'push' }}
         uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           token_format: access_token
@@ -154,6 +134,7 @@ jobs:
           workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
 
       - name: Login to GCR
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: eu.gcr.io
@@ -177,8 +158,9 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          platforms: ${{ github.event_name == 'push' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: |
             eu.gcr.io/loveholidays-ci-cd/ripley:latest
             eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }}
@@ -187,4 +169,4 @@ jobs:
 
       - name: Test Docker image
         run: |
-          docker run --rm eu.gcr.io/loveholidays-ci-cd/ripley:latest --help
+          docker run --rm eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }} --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,7 @@ jobs:
 
   docker-gcr:
     name: Docker Push GCR
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [test, build, docker]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,12 @@
 name: CI
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions:
   id-token: write
   contents: write
-
 jobs:
   test:
     name: Test
@@ -17,16 +14,13 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -36,56 +30,33 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
-
       - name: Download dependencies
         run: go mod download
-
       - name: Verify dependencies
         run: go mod verify
-
       - name: Run tests
         run: go test -v -race ./...
-
       - name: Test linkerdxripley tool
         run: |
           cd tools/linkerdxripley
           go test -v -race ./...
-
   build:
     name: Binaries Build
     runs-on: ubuntu-latest
     needs: test
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-        with:
-          token_format: access_token
-          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
-          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
-
-      - name: Login to GCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: eu.gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
+      - name: Authenticate
+        uses: loveholidays/github-actions/.github/actions/auth-cicd@v1
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
-
       - name: docker registry configure europe-docker.pkg.dev for gcloud
         run: gcloud auth configure-docker europe-docker.pkg.dev
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
-
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -95,20 +66,16 @@ jobs:
           key: ${{ runner.os }}-go-1.23.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-1.23.x-
-
       - name: Build main binary
         run: go build -v -o ripley main.go
-
       - name: Build linkerdxripley tool
         run: |
           cd tools/linkerdxripley
           go build -v -o linkerdxripley main.go
-
       - name: Test binaries work
         run: |
           ./ripley --help
           ./tools/linkerdxripley/linkerdxripley --help
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -116,62 +83,39 @@ jobs:
           path: |
             ripley
             tools/linkerdxripley/linkerdxripley
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=5m
-
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
     needs: [test, build]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-        with:
-          token_format: access_token
-          service_account: gcr-sa-cicd@loveholidays-ci-cd.iam.gserviceaccount.com
-          workload_identity_provider: projects/829253466767/locations/global/workloadIdentityPools/github-actions-idp/providers/github-actions-idp
-
-      - name: Login to GCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: eu.gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
+      - name: Authenticate
+        uses: loveholidays/github-actions/.github/actions/auth-cicd@v1
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: binaries
           path: .
-
       - name: Make binaries executable
         run: chmod +x ripley tools/linkerdxripley/linkerdxripley
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
@@ -184,7 +128,6 @@ jobs:
             eu.gcr.io/loveholidays-ci-cd/ripley:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
       - name: Test Docker image
         run: |
           docker run --rm eu.gcr.io/loveholidays-ci-cd/ripley:latest --help

--- a/README.md
+++ b/README.md
@@ -239,4 +239,9 @@ go test pkg/*.go
 ```
 
 ## Releasing new versions
-Push a new tag to `main` to trigger the GoReleaser process.
+A successful merge to `main` creates a release tag and starts GoReleaser.
+
+- Normal merge: increments the minor version, for example `v0.1.3` to `v0.2.0`.
+- Merge commit message containing `#major`: increments the major version, for example `v0.1.3` to `v1.0.0`.
+
+Do not create release tags manually.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,29 @@ produces
 
 Results output can be suppressed using the `-silent` flag.
 
+## Metrics and profiling
+
+Enable Prometheus metrics with `-metricsServerEnable`. Ripley listens on
+`0.0.0.0:8081` by default and exposes metrics at `/metrics`.
+
+Use `-pushgateway-url`, `-pushgateway-job`, and `-pushgateway-interval` to
+persist metrics for short-lived Jobs. Ripley pushes immediately, at the configured
+interval, and when it exits normally.
+
+Use `-pprof-enable` with `-metricsServerEnable` to expose Go profiles on the same
+listener. Keep this endpoint private. During an active run, use port-forwarding to
+inspect:
+
+```text
+/debug/pprof/goroutine?debug=1
+/debug/pprof/heap
+/debug/pprof/profile?seconds=30
+/debug/pprof/threadcreate
+/debug/pprof/block
+/debug/pprof/mutex
+/debug/pprof/trace?seconds=5
+```
+
 For an example of working with ripley's output to generate statistics, refer to https://gist.github.com/georgemalamidis-lh/39b4f4a6c9c82f6cc8b7370219e93cd2
 
 ```bash

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
+	"time"
 
 	ripley "github.com/loveholidays/ripley/pkg"
 )
@@ -43,6 +44,10 @@ func main() {
 	numWorkers := flag.Int("workers", runtime.NumCPU()*2, "Number of client workers to use")
 	metricsServerEnable := flag.Bool("metricsServerEnable", false, "Enable Prometheus metrics server on /metrics endpoint")
 	metricsServerAddr := flag.String("metricsServerAddr", "0.0.0.0:8081", "Metrics server listen address")
+	pushgatewayURL := flag.String("pushgateway-url", "", "Push Prometheus metrics to this Pushgateway URL")
+	pushgatewayJob := flag.String("pushgateway-job", "ripley", "Pushgateway job name")
+	pushgatewayInterval := flag.Duration("pushgateway-interval", 30*time.Second, "Interval for pushing Prometheus metrics")
+	pprofEnable := flag.Bool("pprof-enable", false, "Enable Go pprof endpoints on the metrics server")
 	printStatsInterval := flag.Duration("print-stats", 0, `Statistics report interval, e.g., "1m"
 
 Each report line is printed to stderr with the following fields in logfmt format:
@@ -92,7 +97,14 @@ When 0 (default) or negative, reporting is switched off.
 		defer pprof.StopCPUProfile()
 	}
 
-	exitCode = ripley.Replay(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers, *connections, *maxConnections, *disableKeepAlives, *printStatsInterval, *metricsServerEnable, *metricsServerAddr)
+	exitCode = ripley.ReplayWithMetricsConfig(*paceStr, *silent, *dryRun, *timeout, *strict, *numWorkers, *connections, *maxConnections, *disableKeepAlives, *printStatsInterval, ripley.MetricsConfig{
+		Enabled:          *metricsServerEnable,
+		Address:          *metricsServerAddr,
+		PushgatewayURL:   *pushgatewayURL,
+		PushgatewayJob:   *pushgatewayJob,
+		PushInterval:     *pushgatewayInterval,
+		ProfilingEnabled: *pprofEnable,
+	})
 
 	if *memprofile != "" {
 		f, err := os.Create(*memprofile)

--- a/pkg/metrics.go
+++ b/pkg/metrics.go
@@ -21,11 +21,13 @@ package ripley
 import (
 	"log"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/push"
 )
 
 var (
@@ -104,8 +106,12 @@ var (
 
 // MetricsConfig holds metrics server configuration
 type MetricsConfig struct {
-	Enabled bool
-	Address string
+	Enabled          bool
+	Address          string
+	PushgatewayURL   string
+	PushgatewayJob   string
+	PushInterval     time.Duration
+	ProfilingEnabled bool
 }
 
 // MetricsRecorder interface for recording metrics
@@ -116,7 +122,8 @@ type MetricsRecorder interface {
 
 // prometheusRecorder implements MetricsRecorder with actual Prometheus metrics
 type prometheusRecorder struct {
-	stopMonitoring chan bool
+	config         MetricsConfig
+	stopMonitoring chan struct{}
 }
 
 // noopRecorder implements MetricsRecorder with no-op implementations
@@ -135,7 +142,10 @@ func NewMetricsRecorder(config MetricsConfig, numWorkers int) MetricsRecorder {
 		}()
 
 		SetWorkerPoolSize(numWorkers)
-		return &prometheusRecorder{stopMonitoring: make(chan bool)}
+		return &prometheusRecorder{
+			config:         config,
+			stopMonitoring: make(chan struct{}),
+		}
 	}
 	return &noopRecorder{}
 }
@@ -146,8 +156,11 @@ func (p *prometheusRecorder) RecordRequest(result *Result) {
 
 func (p *prometheusRecorder) StartMonitoring(requests chan *Request, results chan *Result) func() {
 	go MonitorQueueSizes(requests, results, p.stopMonitoring)
+	if p.config.PushgatewayURL != "" {
+		go PushMetrics(p.config, p.stopMonitoring)
+	}
 	return func() {
-		p.stopMonitoring <- true
+		close(p.stopMonitoring)
 	}
 }
 
@@ -181,6 +194,9 @@ func StartMetricsServer(config MetricsConfig) <-chan error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	if config.ProfilingEnabled {
+		registerPprofHandlers(mux)
+	}
 
 	server := &http.Server{
 		Addr:    config.Address,
@@ -197,6 +213,41 @@ func StartMetricsServer(config MetricsConfig) <-chan error {
 	}()
 
 	return errChan
+}
+
+func registerPprofHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
+func PushMetrics(config MetricsConfig, done <-chan struct{}) {
+	interval := config.PushInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	pushMetrics(config)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			pushMetrics(config)
+			return
+		case <-ticker.C:
+			pushMetrics(config)
+		}
+	}
+}
+
+func pushMetrics(config MetricsConfig) {
+	if err := push.New(config.PushgatewayURL, config.PushgatewayJob).Gatherer(prometheus.DefaultGatherer).Push(); err != nil {
+		log.Printf("WARNING: Failed to push metrics to Pushgateway: %v", err)
+	}
 }
 
 // extractHost extracts the host from a URL to prevent high cardinality issues.
@@ -235,7 +286,7 @@ func SetPacerPhase(phase string, rate float64) {
 }
 
 // MonitorQueueSizes monitors the request and result queue sizes
-func MonitorQueueSizes(requests chan *Request, results chan *Result, done chan bool) {
+func MonitorQueueSizes(requests chan *Request, results chan *Result, done <-chan struct{}) {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 

--- a/pkg/metrics_test.go
+++ b/pkg/metrics_test.go
@@ -21,6 +21,7 @@ package ripley
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -276,6 +277,71 @@ func TestStartMetricsServer_Disabled(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Error("Channel should be closed immediately when disabled")
+	}
+}
+
+func TestStartMetricsServer_ProfilingEnabled(t *testing.T) {
+	config := MetricsConfig{
+		Enabled:          true,
+		Address:          "localhost:18088",
+		ProfilingEnabled: true,
+	}
+
+	StartMetricsServer(config)
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := http.Get("http://localhost:18088/debug/pprof/goroutine?debug=1")
+	if err != nil {
+		t.Fatalf("Failed to access pprof endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read pprof response: %v", err)
+	}
+	if !strings.Contains(string(body), "goroutine profile") {
+		t.Error("pprof goroutine profile was not returned")
+	}
+}
+
+func TestPushMetrics(t *testing.T) {
+	pushes := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pushes <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		PushMetrics(MetricsConfig{
+			PushgatewayURL: server.URL,
+			PushgatewayJob: "ripley-test",
+			PushInterval:   time.Hour,
+		}, done)
+		close(finished)
+	}()
+
+	select {
+	case path := <-pushes:
+		if path != "/metrics/job/ripley-test" {
+			t.Errorf("Unexpected Pushgateway path: %s", path)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Expected metrics to be pushed")
+	}
+
+	close(done)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("Expected metrics push loop to stop")
 	}
 }
 

--- a/pkg/replay.go
+++ b/pkg/replay.go
@@ -28,6 +28,13 @@ import (
 )
 
 func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers, connections, maxConnections int, disableKeepAlives bool, printStatsInterval time.Duration, metricsServerEnable bool, metricsServerAddr string) int {
+	return ReplayWithMetricsConfig(phasesStr, silent, dryRun, timeout, strict, numWorkers, connections, maxConnections, disableKeepAlives, printStatsInterval, MetricsConfig{
+		Enabled: metricsServerEnable,
+		Address: metricsServerAddr,
+	})
+}
+
+func ReplayWithMetricsConfig(phasesStr string, silent, dryRun bool, timeout int, strict bool, numWorkers, connections, maxConnections int, disableKeepAlives bool, printStatsInterval time.Duration, metricsConfig MetricsConfig) int {
 	// Default exit code
 	var exitCode = 0
 	// Ensures we have handled all HTTP Request results before exiting
@@ -42,10 +49,7 @@ func Replay(phasesStr string, silent, dryRun bool, timeout int, strict bool, num
 	results := make(chan *Result)
 
 	// Initialize metrics recorder (no-op if disabled)
-	metricsRecorder := NewMetricsRecorder(MetricsConfig{
-		Enabled: metricsServerEnable,
-		Address: metricsServerAddr,
-	}, numWorkers)
+	metricsRecorder := NewMetricsRecorder(metricsConfig, numWorkers)
 	stopMonitoring := metricsRecorder.StartMonitoring(requests, results)
 	defer stopMonitoring()
 


### PR DESCRIPTION
## Why
OwlBot is a short-lived Ripley workload. Its metrics endpoint disappears when the Job exits, which prevents diagnosis of stalled or terminated runs.

This change adds periodic Pushgateway publishing and an opt-in private pprof endpoint. It keeps per-request output disabled. It also separates untrusted pull-request image builds from two parallel trusted image publication paths and automatically creates semantic-version release tags after successful merges to `main`.

## Alternatives considered
- Scrape the OwlBot pod directly with a PodMonitor: rejected because CronJob pods are short-lived and their final metrics can be lost when the pod exits.
- Enable normal Ripley output: rejected because it emits one line per replayed request and creates excessive log volume.
- Publish registry images from a pull request: rejected because pull-request workflows are not a trusted publication boundary and the Workload Identity provider permits this public repository only for branch-push events.
- Publish Docker Hub and GCR images sequentially: rejected because they use independent credentials and registries.
- Create release tags manually: rejected because each successful `main` merge should have a traceable, consistent release version.

## Impact assessment
Existing Ripley users keep current behaviour because metrics publishing and pprof are disabled by default. The pprof listener is only exposed on the existing metrics port; Flux will not create a Service or public route.

Pull requests build and test a local AMD64 image only. Both registry jobs are skipped. A push to `main` starts the two parallel publication jobs: GCR publishes AMD64 and ARM64 images, and Docker Hub publishes the same tags to `loveholidays/ripley`. Both paths publish `latest` and the commit SHA. Once both paths and all checks succeed, the workflow creates one annotated tag for the merge commit. Normal merges increment the minor version; `#major` in the merge commit message increments the major version. The GCR path depends on merged terraform-automation PR #9655.

## Manual verification performed
- `go test ./...` passed.
- `go vet ./...` and `go build ./...` passed.
- Built the Docker image locally and ran `ripley --help`.
- Parsed `.github/workflows/ci.yaml` with the Ruby YAML parser. `actionlint` and `yamllint` are not installed locally.
- Added tests for Pushgateway request delivery and the pprof goroutine endpoint.
- Verified release calculation with `v0.1.3`: normal merge produces `v0.2.0`; `#major` produces `v1.0.0`. No tag was created during verification.

## CONTEXT
OwlBot reached `DeadlineExceeded` after the Loki fetch and input-conversion init containers completed. The main Ripley container did not provide enough runtime evidence to determine whether it blocked on HTTP I/O, a Go goroutine, or another runtime condition. Metrics must persist beyond a CronJob pod lifetime, and pprof must remain private for incident use.

Ripley is public. Its GitHub Actions workflow must not depend on private shared Actions. Docker Hub publishing was validated from this pull request during the temporary validation configuration. Both registry publishing jobs now run only for pushes to `main`; this also satisfies the live Workload Identity condition for GCR. The tag job uses the existing `TOKEN_GORELEASER` rather than `GITHUB_TOKEN`, because a default-token tag push would not trigger the GoReleaser workflow.