### PR TITLE
Fix release tag checkout authentication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,7 +229,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.TOKEN_GORELEASER }}
 
       - name: Calculate release version
         id: version
@@ -268,11 +267,13 @@ jobs:
       - name: Push release tag
         if: ${{ steps.version.outputs.create_tag == 'true' }}
         env:
+          RELEASE_TOKEN: ${{ secrets.TOKEN_GORELEASER }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"


### PR DESCRIPTION
## Why
The `Create release tag` job failed on the `main` merge commit `3885a0fcf7b44509b454bd95c33cb5b26a3d61f5`. `actions/checkout` used `TOKEN_GORELEASER` and could not authenticate its full-history tag fetch. This blocked automatic release tags and therefore the GoReleaser workflow.

## Alternatives considered
- Continue using `TOKEN_GORELEASER` for checkout: rejected because its repository fetch returned `could not read Username`.
- Use `GITHUB_TOKEN` to push the tag: rejected because tag pushes made by the default token do not trigger the tag-based GoReleaser workflow.

## Impact assessment
The release-tag job now uses the default GitHub Actions token only for reading repository history. It uses `TOKEN_GORELEASER` only for the final tag push, which preserves the tag-triggered GoReleaser flow. Pull requests and image publication jobs are unchanged.

## Manual verification performed
- Parsed `.github/workflows/ci.yaml` successfully with Ruby YAML.
- Inspected the failed `main` run `32142391912`: failure occurred during `actions/checkout` before the release-version logic ran.
- No release tag was created during this verification.

## CONTEXT
OwlBot needs the newly published Ripley commit image. The merge-to-main CI push succeeded, but the subsequent automatic release-tag job failed because `TOKEN_GORELEASER` could not fetch this public repository. The checkout and tag-push credentials are now separated to limit the failing token to the operation that requires it.